### PR TITLE
SETF STREAM-FILE-POSITION should return NEWVAL

### DIFF
--- a/streams.lisp
+++ b/streams.lisp
@@ -69,8 +69,7 @@
   nil)
 
 (defmethod (setf stream-file-position) (newval (stream t))
-  (declare (ignore newval))
-  nil)
+  newval)
 
 #+abcl
 (progn


### PR DESCRIPTION
Standard-compliant SETF functions should always return NEWVAL.