### PR TITLE
Add file attributes for Genera

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -1,3 +1,5 @@
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: CL-USER -*-
+
 #+xcvb (module ())
 
 (in-package :cl-user)

--- a/streams.lisp
+++ b/streams.lisp
@@ -1,3 +1,5 @@
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: TRIVIAL-GRAY-STREAMS -*-
+
 #+xcvb (module (:depends-on ("package")))
 
 (in-package :trivial-gray-streams)

--- a/test/package.lisp
+++ b/test/package.lisp
@@ -1,3 +1,5 @@
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: CL-USER -*-
+
 (defpackage trivial-gray-streams-test 
   (:use :cl #:trivial-gray-streams)
   (:shadow #:method)

--- a/test/run-on-many-lisps.lisp
+++ b/test/run-on-many-lisps.lisp
@@ -1,3 +1,5 @@
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: CL-USER -*-
+
 (ql:quickload :trivial-gray-streams)
 (ql:quickload :test-grid-agent)
 (ql:quickload :cl-fad)

--- a/test/test-framework.lisp
+++ b/test/test-framework.lisp
@@ -1,3 +1,4 @@
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: TRIVIAL-GRAY-STREAMS-TEST -*-
 (in-package :trivial-gray-streams-test)
 
 ;;; test framework

--- a/test/test.lisp
+++ b/test/test.lisp
@@ -1,3 +1,4 @@
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: TRIVIAL-GRAY-STREAMS-TEST -*-
 (in-package :trivial-gray-streams-test)
 
 ;;; assert-invoked - a tool to check that specified method with parameters has

--- a/trivial-gray-streams-test.asd
+++ b/trivial-gray-streams-test.asd
@@ -1,4 +1,4 @@
-;;; -*- mode: lisp -*-
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; -*-
 
 (defsystem :trivial-gray-streams-test
   :version "2.0"

--- a/trivial-gray-streams.asd
+++ b/trivial-gray-streams.asd
@@ -1,4 +1,4 @@
-;;; -*- mode: lisp -*-
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; -*-
 
 (defsystem :trivial-gray-streams
   :description "Compatibility layer for Gray Streams (see http://www.cliki.net/Gray%20streams)."


### PR DESCRIPTION
Genera doesn't handle (in-package ...) the way that most people expect, but instead uses the Package file attribute to determine which package to place definitions. This is easily fixed by adding a comment line of the form:
```lisp
;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: CL-USER -*-
```
at the top of the file, with no change to the lisp code required.