### PR TITLE
Add support for ManKai CL

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -46,12 +46,12 @@
                #+sbcl :sb-gray
                #+allegro :excl
                #+cmu :ext
-               #+(or clisp ecl mocl clasp) :gray
+               #+(or clisp ecl mkcl mocl clasp) :gray
                #+openmcl :ccl
                #+lispworks :stream
                #+(or abcl genera) :gray-streams
                #+mezzano :mezzano.gray
-               #-(or sbcl allegro cmu clisp openmcl lispworks ecl clasp abcl mocl genera mezzano) ...
+               #-(or sbcl allegro cmu clisp openmcl lispworks ecl clasp mkcl abcl mocl genera mezzano) ...
                ,@gray-class-symbols
                ,@gray-function-symbols)
               (:export

--- a/streams.lisp
+++ b/streams.lisp
@@ -246,7 +246,7 @@
   (defmethod sb-gray:stream-line-length ((stream fundamental-stream))
     80))
 
-#+(or ecl clasp)
+#+(or ecl clasp mkcl)
 (progn
   (defmethod gray::stream-file-position 
     ((stream fundamental-stream) &optional position)


### PR DESCRIPTION
Its a derivative of ECL so it much like ECL or CLASP. They don't appear to be using the REDEFINE-CL-FUNCTIONS anymore.